### PR TITLE
support partial callbackHandler

### DIFF
--- a/src/main/java/com/sohu/jafka/producer/async/AsyncProducer.java
+++ b/src/main/java/com/sohu/jafka/producer/async/AsyncProducer.java
@@ -136,7 +136,7 @@ public class AsyncProducer<T> implements Closeable {
         } catch (InterruptedException e) {
             throw new AsyncProducerInterruptedException(e);
         }
-        if (this.callbackHandler != null) {
+        if (this.callbackHandler != null && this.callbackHandler.beforeEnqueue(data) != null) {
             this.callbackHandler.afterEnqueue(data, added);
         }
         if (!added) {

--- a/src/main/java/com/sohu/jafka/producer/async/DefaultEventHandler.java
+++ b/src/main/java/com/sohu/jafka/producer/async/DefaultEventHandler.java
@@ -64,7 +64,7 @@ public class DefaultEventHandler<T> implements EventHandler<T> {
 
     public void handle(List<QueueItem<T>> events, SyncProducer producer, Encoder<T> encoder) {
         List<QueueItem<T>> processedEvents = events;
-        if (this.callbackHandler != null) {
+        if (this.callbackHandler != null && this.callbackHandler.beforeSendingData(events) != null) {
             processedEvents = this.callbackHandler.beforeSendingData(events);
         }
         send(collate(processedEvents, encoder), producer);

--- a/src/main/java/com/sohu/jafka/producer/async/ProducerSendThread.java
+++ b/src/main/java/com/sohu/jafka/producer/async/ProducerSendThread.java
@@ -120,7 +120,7 @@ public class ProducerSendThread<T> extends Thread {
                 long elapsed =  System.currentTimeMillis()- lastSend;
                 boolean expired = item == null;
                 if (item != null) {
-                    if (callbackHandler != null) {
+                    if (callbackHandler != null && callbackHandler.afterDequeuingExistingData(item) != null) {
                         events.addAll(callbackHandler.afterDequeuingExistingData(item));
                     } else {
                         events.add(item);
@@ -147,7 +147,7 @@ public class ProducerSendThread<T> extends Thread {
         if (queue.size() > 0) {
             throw new IllegalQueueStateException("Invalid queue state! After queue shutdown, " + queue.size() + " remaining items in the queue");
         }
-        if (this.callbackHandler != null) {
+        if (this.callbackHandler != null && this.callbackHandler.lastBatchBeforeClose() != null) {
             events.addAll(callbackHandler.lastBatchBeforeClose());
         }
         return events;


### PR DESCRIPTION
It's not working properly when 7 method of callbackHandler aren't fully implemented.
And it's difficult to implement all of the method in callbackHandler.
It is possible to implement partial callbackHandler after merging this patch.
