### PR TITLE
fixed that queue.offer isn't executed when beforeEnqueue method isn't implemented

### DIFF
--- a/src/main/java/com/sohu/jafka/producer/async/AsyncProducer.java
+++ b/src/main/java/com/sohu/jafka/producer/async/AsyncProducer.java
@@ -121,7 +121,10 @@ public class AsyncProducer<T> implements Closeable {
         }
         QueueItem<T> data = new QueueItem<T>(event, partition, topic);
         if (this.callbackHandler != null) {
-            data = this.callbackHandler.beforeEnqueue(data);
+            QueueItem<T> item = this.callbackHandler.beforeEnqueue(data);
+            if (item != null) {
+                data = this.callbackHandler.beforeEnqueue(data);
+            }
         }
 
         boolean added = false;


### PR DESCRIPTION
queue.offer() isn't executed when callbackHandler.beforeEnqueue returns null.
